### PR TITLE
Fix `bal push` failure due to non-existing source in default module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ plugins {
 }
 
 allprojects {
-    apply plugin: 'maven-publish'
-
     group = project.group
     version = project.version
+
+    apply plugin: 'maven-publish'
 
     repositories {
         mavenLocal()
@@ -63,14 +63,17 @@ allprojects {
     }
 }
 
+def moduleVersion = project.version.replace("-SNAPSHOT", "")
+
 subprojects {
     configurations {
         ballerinaStdLibs
         jbalTools
     }
-}
 
-def moduleVersion = project.version.replace("-SNAPSHOT", "")
+    dependencies {
+    }
+}
 
 task build {
     dependsOn(':candid-ballerina:build')


### PR DESCRIPTION
## Purpose
$title.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
